### PR TITLE
Fixed typo, added runlevel dependencies

### DIFF
--- a/as/etc/init-script.deb
+++ b/as/etc/init-script.deb
@@ -6,12 +6,12 @@
 # this is a very minimal init script!
 
 ### BEGIN INIT INFO
-# Provides:		asd
-# Required-Start:
-# Required-Stop:
-# Default-Start:
-# Deafult-Stop:
-# Short-Description:	Aerospike Clustered Data Service
+# Provides:             asd
+# Required-Start:       $remote_fs $network
+# Required-Stop:        $remote_fs $network
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Short-Description:    Aerospike Clustered Data Service
 ### END INIT INFO
 
 # halt on error


### PR DESCRIPTION
The type "Deafult-Stop" vs. "Default-Stop" prevents update-rc.d from reading the file properly.

Adding the dependencies and runlevel configurations installs the service properly into the system's startup
